### PR TITLE
Fix docs and util to use collection rather than sequence

### DIFF
--- a/sunkit_dem/tests/test_util.py
+++ b/sunkit_dem/tests/test_util.py
@@ -1,31 +1,35 @@
 """
 Tests for utilities
 """
+import ndcube
 import numpy as np
 import pytest
 
 import astropy.units as u
 
-from sunkit_dem.util import quantity_1d_to_sequence
+from sunkit_dem.util import quantity_1d_to_collection
 
 wavelengths = np.linspace(0, 1, 10) * u.angstrom
-intensities = np.random.rand(wavelengths.shape[0]) * u.ct
+intensities = np.random.rand(wavelengths.shape[0]) * u.photon
 
 
 @pytest.fixture
-def sequence1d():
-    return quantity_1d_to_sequence(intensities, wavelengths)
+def collection1d():
+    return quantity_1d_to_collection(intensities, wavelengths)
 
 
-def test_dimensions(sequence1d):
-    assert sequence1d.cube_like_shape == [10]
+def test_is_collection(collection1d):
+    assert isinstance(collection1d, ndcube.NDCollection)
 
 
-def test_common_axis(sequence1d):
-    common_axis = u.Quantity(sequence1d.common_axis_coords[0])
-    assert common_axis.shape == wavelengths.shape
-    assert u.allclose(common_axis, wavelengths, rtol=1e-10)
+def test_wavelengths(collection1d):
+    wavelength_axis = u.Quantity([collection1d[k].axis_world_coords()[0] for k in collection1d.keys()]).squeeze()
+    assert u.allclose(wavelength_axis, wavelengths)
 
 
-def test_axis_type(sequence1d):
-    assert sequence1d.cube_like_array_axis_physical_types == [('em.wl',)]
+def test_axis_type(collection1d):
+    assert all([collection1d[k].array_axis_physical_types == [('em.wl',)] for k in collection1d.keys()])
+
+def test_data(collection1d):
+    collection_data = u.Quantity([collection1d[k].quantity for k in collection1d.keys()]).squeeze()
+    assert u.allclose(intensities, collection_data)

--- a/sunkit_dem/util.py
+++ b/sunkit_dem/util.py
@@ -8,11 +8,11 @@ import astropy.units as u
 from astropy.nddata import StdDevUncertainty
 from astropy.wcs import WCS
 
-__all__ = ["quantity_1d_to_sequence"]
+__all__ = ["quantity_1d_to_collection"]
 
 
 @u.quantity_input
-def quantity_1d_to_sequence(intensity, wavelength: u.angstrom, uncertainty=None, meta=None):
+def quantity_1d_to_collection(intensity, wavelength: u.angstrom, uncertainty=None, meta=None):
     """
     Transform 1D `~astropy.units.Quantity` of intensities to a single-axis
     `~ndcube.NDCubeSequence`.
@@ -27,6 +27,11 @@ def quantity_1d_to_sequence(intensity, wavelength: u.angstrom, uncertainty=None,
     uncertainty : `~astrpoy.units.Quantity`, optional
         Uncertainties on intensities
     meta : `dict` or `dict`-like, optional
+
+    Returns
+    -------
+    : `~ndcube.NDCollection`
+        Collection of intensities with keys corresponding to ``wavelengths``
     """
     cubes = []
     for j, (i, w) in enumerate(zip(intensity, wavelength)):
@@ -40,10 +45,11 @@ def quantity_1d_to_sequence(intensity, wavelength: u.angstrom, uncertainty=None,
                'CRPIX1': 1,
                'CRVAL1': w.value,
                'NAXIS1': 1}
-        cubes.append(ndcube.NDCube(
+        cube = ndcube.NDCube(
             i[np.newaxis],
             WCS(wcs),
             meta=meta,
             uncertainty=_uncertainty,
-        ))
-    return ndcube.NDCubeSequence(cubes, common_axis=0)
+        )
+        cubes.append((str(w), cube))
+    return ndcube.NDCollection(cubes)


### PR DESCRIPTION
Input data is expected to be passed in as an `NDCollection`. This fixes the docs in several places which previously said it should be a sequence. Also fixes the utility function that previously cast a quantity to a sequence to now make a collection instead.

Additionally, this adds two properties to `GenericModel`:
- `temperature_bin_widths`
- `uncertainty_matrix`